### PR TITLE
Add support for `desktop.goto(url)` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,24 @@ def get_screenshot(self) -> str:
 
 ---
 
+### **`goto(url)`**
+
+```python
+def goto(self, url: str) -> None:
+    """
+    Open Firefox in the container and navigate to the specified URL in a new tab.
+    """
+```
+
+**Arguments**:
+- **url** *(str)*: The URL to navigate to (e.g., `https://example.com`).
+
+**Behavior**:
+- Opens Firefox in the container and navigates to the specified URL in a new tab
+
+**Returns**:
+- `None`
+
 ## OpenAI Agent Integration
 
 ### **`action(input_text=None, acknowledged_safety_checks=False, ignore_safety_and_input=False, complete_handler=None, needs_input_handler=None, needs_safety_check_handler=None, error_handler=None)`**

--- a/examples/amazon_example.py
+++ b/examples/amazon_example.py
@@ -70,6 +70,7 @@ def main():
     # Start up an isolated desktop. Edit desktop name, and docker_image if needed
     desktop = Desktop(name="newdesktop")
     container = desktop.start()
+    desktop.goto("https://www.amazon.com")
     print("🍰 spongecake container started:", container)
     print("...\n")
 
@@ -91,7 +92,7 @@ def main():
         
         user_prompt = f"""
             # AGENT INSTRUCTIONS #
-            Go to www.amazon.com
+            You are currently on www.amazon.com
 
             Search for 'sponge cake plush'
 

--- a/spongecake/spongecake/desktop.py
+++ b/spongecake/spongecake/desktop.py
@@ -454,6 +454,21 @@ class Desktop:
 
         # proc.stdout is now our base64-encoded screenshot
         return proc.stdout.strip()
+    
+    # ----------------------------------------------------------------
+    # GOTO URL
+    # ----------------------------------------------------------------
+    def goto(self, url: str) -> None:
+        """
+        Open Firefox in the container and navigate to the specified URL.
+        
+        Args:
+            url: The URL to navigate to (e.g., "https://example.com")
+        """
+        logger.info(f"Action: goto URL: {url}")
+        # add `&` at the end to run Firefox in background and have `self.exec` return immediately
+        command = f"export DISPLAY={self.display} && firefox-esr -new-tab {url} &"
+        self.exec(command)
 
     # -------------------------
     # Agent Integration


### PR DESCRIPTION
This patch adds support for the `desktop.goto(url)` action, which opens the url in a new Firefox tab using the [`-new-tab`](https://wiki.mozilla.org/Firefox/CommandLineOptions#-new-tab_URL) flag. Note that we use the `firefox-esr` command since the Dockerfile installs the firefox-esr package.

Manually visiting a URL can be useful when:
- we already know the starting condition (e.g. "start on amazon.com") and want to shave a few seconds
- we want to save tokens spent on visiting a known URL

