### PR TITLE
Implement tracing

### DIFF
--- a/examples/amazon_example.py
+++ b/examples/amazon_example.py
@@ -2,8 +2,9 @@
 import logging
 from time import sleep
 from dotenv import load_dotenv
-from spongecake import Desktop, AgentStatus
+from spongecake import Desktop, AgentStatus, TraceConfig
 import subprocess
+import json
 
 # Configure logging - most logs in the SDK are INFO level logs
 logging.basicConfig(
@@ -61,6 +62,9 @@ def error_handler(error_message):
     print(f"😱 ERROR: {error_message}")
     result[0] = None  # Just return None on error
 
+def log_trace(trace_data):
+    print(f"Trace {trace_data['trace_id']} completed:")
+    print(json.dumps(trace_data, indent=2))
 
 # -------------------------
 # Main
@@ -68,7 +72,8 @@ def error_handler(error_message):
 
 def main():
     # Start up an isolated desktop. Edit desktop name, and docker_image if needed
-    desktop = Desktop(name="newdesktop")
+    trace_config = TraceConfig(callback=log_trace)
+    desktop = Desktop(name="newdesktop", trace_config=trace_config)
     container = desktop.start()
     desktop.goto("https://www.amazon.com")
     print("🍰 spongecake container started:", container)
@@ -127,7 +132,8 @@ def main():
                 complete_handler=complete_handler,
                 needs_input_handler=needs_input_handler,
                 needs_safety_check_handler=needs_safety_check_handler,
-                error_handler=error_handler
+                error_handler=error_handler,
+                trace_id="some_id"
             )
 
         # Show final results

--- a/examples/amazon_example.py
+++ b/examples/amazon_example.py
@@ -132,8 +132,7 @@ def main():
                 complete_handler=complete_handler,
                 needs_input_handler=needs_input_handler,
                 needs_safety_check_handler=needs_safety_check_handler,
-                error_handler=error_handler,
-                trace_id="some_id"
+                error_handler=error_handler
             )
 
         # Show final results

--- a/spongecake-sdk/spongecake/__init__.py
+++ b/spongecake-sdk/spongecake/__init__.py
@@ -1,5 +1,6 @@
 from .desktop import Desktop
 from .agent import Agent
 from .constants import AgentStatus
+from .trace import TraceConfig
 
-__all__ = ["Desktop", "AgentStatus", "Agent"]
+__all__ = ["Desktop", "AgentStatus", "Agent", "TraceConfig"]

--- a/spongecake-sdk/spongecake/agent.py
+++ b/spongecake-sdk/spongecake/agent.py
@@ -842,6 +842,9 @@ Respond with only a single digit: 1 (yes, asking for input) or 0 (no, providing 
         if previous_response_id:
             params["previous_response_id"] = previous_response_id
             
+        if self.desktop.tracer.config.trace_api_calls:
+            self.desktop.tracer.add_entry("api_call", endpoint="openai/responses", params=params)
+
         try:
             return self.openai_client.responses.create(**params)
         except Exception as e:

--- a/spongecake-sdk/spongecake/desktop.py
+++ b/spongecake-sdk/spongecake/desktop.py
@@ -16,6 +16,7 @@ from openai import OpenAI
 from .constants import AgentStatus
 from .trace import Tracer, TraceConfig
 from typing import Optional
+import uuid
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -566,7 +567,7 @@ class Desktop:
             # If the response comes from the fallback command
             screenshot_bytes = response["result"]
         if self.tracer.config.trace_screenshots:
-            self.tracer.add_entry("screenshot", screeshot=f"data:image/png;base64,{screenshot_bytes}")
+            self.tracer.add_entry("screenshot", screenshot=f"data:image/png;base64,{screenshot_bytes}")
         return screenshot_bytes
     
     # ----------------------------------------------------------------
@@ -725,7 +726,7 @@ class Desktop:
         return self.get_agent().get_page_html(query)
             
     def action(self, input_text=None, acknowledged_safety_checks=False, ignore_safety_and_input=False,
-              complete_handler=None, needs_input_handler=None, needs_safety_check_handler=None, error_handler=None, tools=None, function_map=None, trace_id: Optional[str] = None, **kwargs):
+              complete_handler=None, needs_input_handler=None, needs_safety_check_handler=None, error_handler=None, tools=None, function_map=None, **kwargs):
         """
         New and improved action command: Execute an action in the desktop environment. This method delegates to the agent's action method.
         
@@ -756,8 +757,7 @@ class Desktop:
             - status is an AgentStatus enum value indicating the result
             - data contains relevant information based on the status
         """
-        if trace_id:
-            self.tracer.start(trace_id)
+        self.tracer.start(str(uuid.uuid4()))
         try:
             # Look for old-style keys in **kwargs:
             old_input = kwargs.get("input")
@@ -796,8 +796,7 @@ class Desktop:
             )
 
         finally:
-            if trace_id:
-                self.tracer.stop()
+            self.tracer.stop()
     
     # exposes context manager for a given trace 
     def trace(self, trace_id: str):

--- a/spongecake-sdk/spongecake/desktop.py
+++ b/spongecake-sdk/spongecake/desktop.py
@@ -565,7 +565,8 @@ class Desktop:
         elif isinstance(response, dict) and "result" in response:
             # If the response comes from the fallback command
             screenshot_bytes = response["result"]
-        self.tracer.add_entry("screenshot", screeshot=screenshot_bytes)
+        if self.tracer.config.trace_screenshots:
+            self.tracer.add_entry("screenshot", screeshot=screenshot_bytes)
         return screenshot_bytes
     
     # ----------------------------------------------------------------

--- a/spongecake-sdk/spongecake/desktop.py
+++ b/spongecake-sdk/spongecake/desktop.py
@@ -566,7 +566,7 @@ class Desktop:
             # If the response comes from the fallback command
             screenshot_bytes = response["result"]
         if self.tracer.config.trace_screenshots:
-            self.tracer.add_entry("screenshot", screeshot=screenshot_bytes)
+            self.tracer.add_entry("screenshot", screeshot=f"data:image/png;base64,{screenshot_bytes}")
         return screenshot_bytes
     
     # ----------------------------------------------------------------

--- a/spongecake-sdk/spongecake/trace.py
+++ b/spongecake-sdk/spongecake/trace.py
@@ -3,6 +3,7 @@ import logging
 from typing import Dict, Any, Callable, Optional
 from contextlib import contextmanager
 
+# Set up a logger for tracing
 logger = logging.getLogger(__name__)
 
 class TraceEntry:
@@ -13,16 +14,17 @@ class TraceEntry:
         self.data = kwargs
 
     def to_dict(self) -> Dict[str, Any]:
+        """Convert the trace entry to a dictionary format."""
         return {"action_type": self.action_type, "timestamp": self.timestamp, **self.data}
 
 class TraceConfig:
-    """Configuration for tracing behavior."""
+    """Configuration class for managing tracing behavior."""
     def __init__(
         self,
-        enabled: bool = True,
-        trace_api_calls: bool = False,
-        trace_screenshots: bool=False,
-        callback: Optional[Callable[[Dict[str, Any]], None]] = None
+        enabled: bool = True,  # Enable or disable tracing
+        trace_api_calls: bool = False,  # Flag to trace API calls
+        trace_screenshots: bool = False,  # Flag to trace screenshots
+        callback: Optional[Callable[[Dict[str, Any]], None]] = None  # Callback function for trace data
     ):
         self.enabled = enabled
         self.trace_api_calls = trace_api_calls
@@ -38,10 +40,14 @@ class Tracer:
     def start(self, trace_id: str) -> None:
         """Start a new trace if tracing is enabled."""
         if self.config.enabled and not self.current_trace:
-            self.current_trace = {"trace_id": trace_id, "start_time": time.time(), "entries": []}
+            self.current_trace = {
+                "trace_id": trace_id,  # Unique identifier for the trace
+                "start_time": time.time(),  # Start time of the trace
+                "entries": []  # List to store trace entries
+            }
 
     def stop(self) -> None:
-        """Stop the current trace and process it."""
+        """Stop the current trace session and process the collected data."""
         if self.current_trace:
             self.current_trace["end_time"] = time.time()
             trace_data = self.current_trace
@@ -66,9 +72,9 @@ class Tracer:
 
     @contextmanager
     def trace(self, trace_id: str):
-        """Context manager for scoped tracing."""
-        self.start(trace_id)
+        """Context manager for scoped tracing, automatically starts and stops tracing."""
+        self.start(trace_id)  # Start tracing
         try:
-            yield
+            yield  # Allow code execution within the trace context
         finally:
-            self.stop()
+            self.stop()  # Ensure tracing is stopped after execution

--- a/spongecake-sdk/spongecake/trace.py
+++ b/spongecake-sdk/spongecake/trace.py
@@ -21,10 +21,12 @@ class TraceConfig:
         self,
         enabled: bool = True,
         trace_api_calls: bool = False,
+        trace_screenshots: bool=False,
         callback: Optional[Callable[[Dict[str, Any]], None]] = None
     ):
         self.enabled = enabled
         self.trace_api_calls = trace_api_calls
+        self.trace_screenshots = trace_screenshots
         self.callback = callback
 
 class Tracer:

--- a/spongecake-sdk/spongecake/trace.py
+++ b/spongecake-sdk/spongecake/trace.py
@@ -1,0 +1,72 @@
+import time
+import logging
+from typing import Dict, Any, Callable, Optional
+from contextlib import contextmanager
+
+logger = logging.getLogger(__name__)
+
+class TraceEntry:
+    """Represents a single event in a trace."""
+    def __init__(self, action_type: str, timestamp: float, **kwargs):
+        self.action_type = action_type
+        self.timestamp = timestamp
+        self.data = kwargs
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"action_type": self.action_type, "timestamp": self.timestamp, **self.data}
+
+class TraceConfig:
+    """Configuration for tracing behavior."""
+    def __init__(
+        self,
+        enabled: bool = True,
+        trace_api_calls: bool = False,
+        callback: Optional[Callable[[Dict[str, Any]], None]] = None
+    ):
+        self.enabled = enabled
+        self.trace_api_calls = trace_api_calls
+        self.callback = callback
+
+class Tracer:
+    """Manages tracing for an application."""
+    def __init__(self, config: TraceConfig = None):
+        self.config = config or TraceConfig()
+        self.current_trace = None
+
+    def start(self, trace_id: str) -> None:
+        """Start a new trace if tracing is enabled."""
+        if self.config.enabled and not self.current_trace:
+            self.current_trace = {"trace_id": trace_id, "start_time": time.time(), "entries": []}
+
+    def stop(self) -> None:
+        """Stop the current trace and process it."""
+        if self.current_trace:
+            self.current_trace["end_time"] = time.time()
+            trace_data = self.current_trace
+            self.current_trace = None
+            self._process_trace(trace_data)
+
+    def add_entry(self, action_type: str, **kwargs) -> None:
+        """Add an entry to the current trace."""
+        if self.current_trace:
+            entry = TraceEntry(action_type, time.time(), **kwargs)
+            self.current_trace["entries"].append(entry.to_dict())
+            logger.debug(f"Added trace entry: {action_type}")
+
+    def _process_trace(self, trace_data: Dict[str, Any]) -> None:
+        """Handle the completed trace by invoking the callback if provided."""
+        if self.config.callback:
+            try:
+                self.config.callback(trace_data)
+                logger.info(f"Trace {trace_data['trace_id']} passed to callback.")
+            except Exception as e:
+                logger.error(f"Error in trace callback: {str(e)}")
+
+    @contextmanager
+    def trace(self, trace_id: str):
+        """Context manager for scoped tracing."""
+        self.start(trace_id)
+        try:
+            yield
+        finally:
+            self.stop()


### PR DESCRIPTION
This patch adds a proof-of-concept to trace CUA actions, similar to the way you can trace LLM calls using platforms like LangChain.

In production, relying on `Action: ...` logs and watching VNC screens live isn't very feasible. This implementation adds a flexible `Tracer` class that keeps appending actions to a list of `TraceEntry` and then passes the trace data to a callback when it ends. The user can implement their own callback to, for example, store the traces in a file / database or just log them.

Sample usage:
```py
trace_config = TraceConfig(callback=store_trace_to_aws, trace_api_calls=True, trace_screenshots=True)
desktop = Desktop(name="newdesktop", trace_config=trace_config)
...
desktop.action(...., trace_id="random_id")
```

Running `amazon_example.py` with a callback that JSON-prints the trace at the end (no screenshots/API calls) - https://app.warp.dev/block/3koFS5swUVnRa4hnNXrL8S

I tried to keep changes to the Desktop / Agent interface to a minimum but may want to reduce them even further. For example, it'd be nice if the end user didn't have to understand `TraceConfig` to implement tracing.

Note that storing VNC screen recordings seemed resource intensive so I went with simple text / screenshot tracing.

----

<b>Documentation to add to Mintlify to explain tracing:</b>

Spongecake has a built-in tracing system you can use to track the sequence of action taking by a `Desktop`, along with timestamps and screenshots. You can control what to do with the trace data by providing your own callback function.

Steps to use tracing:

**1. Define a callback function**

This function takes in `trace_data` (a dictionary containing the trace ID, timestamps, and a list of action entries). You can log, store, or process this data as needed.

Example callbacks:

```py
import json

# callback to log a trace
def log_trace(trace_data):
    print(f"Trace {trace_data['trace_id']} completed:")
    print(json.dumps(trace_data, indent=2))
    
# callback to save trace to a file
def save_trace(trace_data):
    with open(f"trace_{trace_data['trace_id']}.json", "w") as f:
        json.dump(trace_data, f, indent=2)
```

**2. Configure Tracing**

Pass a `TraceConfig` instance to your `Desktop` with your callback. You can also enable tracing of API calls and screenshots if needed.

```py
from spongecake import Desktop, TraceConfig

trace_config = TraceConfig(
    enabled=True,          # Enable tracing (default: True)
    trace_api_calls=False, # Trace API calls (default: False)
    trace_screenshots=False # Trace screenshots, stored as base64 data
    callback=log_trace     # Your custom callback
)
desktop = Desktop(name="newdesktop", trace_config=trace_config)
```