### PR TITLE
fix response destructuring in `server.py` for AgentStatus.COMPLETE

### DIFF
--- a/spongecake-ui/backend/server.py
+++ b/spongecake-ui/backend/server.py
@@ -162,7 +162,10 @@ class SpongecakeServer:
                 agent_response = None
             else:
                 logs.append(f"✅ Agent status: {status}")
-                agent_response = str(data[0].content[0].text)
+                if (status == AgentStatus.COMPLETE):
+                    agent_response = data.output[1].content[0].text
+                else:
+                    agent_response = str(data[0].content[0].text)
                 
         except Exception as exc:
             error_msg = f"❌ Exception while running action: {exc}"


### PR DESCRIPTION
When the agent finishes a turn with status "complete", the return value of `data` is actually like a `Response()` object whose output message is hidden under `Response.output[1].content[0].text`.

Trying to do `str(data[0].content[0].text)` results in a destructuring error - https://app.warp.dev/block/NcnmP4iX42zZQbvmRzCjl0

Indexing into the object correctly works - https://app.warp.dev/block/E0iek21k8dDL8L1yT21Otz

And the output is correctly printed out into the Chat UI -
<img width="463" alt="Screenshot 2025-04-07 at 5 11 43 PM" src="https://github.com/user-attachments/assets/08455b82-466d-40a3-bcf1-e03d1d29a7a6" />
