### PR TITLE
Small refactors for cleanup

### DIFF
--- a/spongecake-sdk/pyproject.toml
+++ b/spongecake-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spongecake"
-version = "0.1.14"
+version = "0.1.15"
 description = "Spongecake is the easiest way to launch OpenAI computer use agents."
 authors = [
   { name = "Terrell Marshall", email = "terrell@passage-team.com" },

--- a/spongecake-sdk/setup.py
+++ b/spongecake-sdk/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="spongecake",
-    version="0.1.14",
+    version="0.1.15",
     description="Open source SDK to launch OpenAI computer use agents",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/spongecake-sdk/spongecake/desktop.py
+++ b/spongecake-sdk/spongecake/desktop.py
@@ -71,7 +71,7 @@ class Desktop:
       unavailable between the initial check and the actual container startup
     """
 
-    def __init__(self, name: str = "newdesktop", docker_image: str = "spongebox/spongecake:latest", vnc_port: int = 5900, api_port: int = None, marionette_port: int = 3838, socat_port: int = 2828, websocket_port: int = 6080, host: str = None, openai_api_key: str = None, create_agent: bool = True, trace_config: Optional[TraceConfig] = None):
+    def __init__(self, name: str = "newdesktop", isLocal: bool = False, docker_image: str = "spongebox/spongecake:latest", vnc_port: int = 5900, api_port: int = None, marionette_port: int = 3838, socat_port: int = 2828, websocket_port: int = 6080, host: str = None, openai_api_key: str = None, create_agent: bool = True, trace_config: Optional[TraceConfig] = None):
         """
         Initialize a new Desktop instance.
         
@@ -100,10 +100,11 @@ class Desktop:
         self.host = host
         self.container_started = False
         self.tracer = Tracer(trace_config)
+        self.isLocal = isLocal
 
         # Initialize environment
         self.scale_factor = 1 # Default scale factor
-        if self.host == 'local':
+        if self.isLocal == True:
             if platform.system() == "Darwin":
                 self.environment = "mac"
                 # Import pyautogui only when needed in Mac environment

--- a/spongecake-ui/backend/server.py
+++ b/spongecake-ui/backend/server.py
@@ -207,14 +207,14 @@ class SpongecakeServer:
         for msg in data.output:
             if hasattr(msg, "content"):
                 text_parts = [part.text for part in msg.content if hasattr(part, "text")]
-                self.result[0] = text_parts
+                self.result[0] = [{"pendingSafetyCheck": False, "messages": text_parts}] 
         
     def needs_input_handler(self, messages):
         """NEEDS_INPUT -- Get input from the user, and pass it back to `action`"""
         for msg in messages:
             if hasattr(msg, "content"):
                 text_parts = [part.text for part in msg.content if hasattr(part, "text")]
-                self.result[0] = text_parts
+                self.result[0] = [{"pendingSafetyCheck": False, "messages": text_parts}] 
 
     def needs_safety_check_handler(self, safety_checks, pending_call):
         # Check if the user has already acknowledged safety checks (set this flag in run_agent_action)
@@ -232,7 +232,7 @@ class SpongecakeServer:
     def error_handler(self, error_message):
         """ERROR -- Handle errors (just print it out in this case)"""
         print(f"😱 ERROR: {error_message}")
-        self.result[0] = None  # Just return None on error
+        self.result[0] = [{"pendingSafetyCheck": False, "messages": None}] # Just return None on error
 
     def run_agent_action(self, user_prompt: str, auto_mode: bool = False, safety_ack: bool = False, log_queue=None, stop_event=None) -> Dict[str, Any]:
         """Run the agent logic in the Spongecake Desktop (while showing the custom cursor overlay if running locally)
@@ -298,20 +298,10 @@ class SpongecakeServer:
         logs.append(log_msg)
         agent_response = self.result[0]
 
-        if (isinstance(agent_response, list) and agent_response and 
-            isinstance(agent_response[0], dict) and agent_response[0].get("pendingSafetyCheck")):
-            return {
-                "logs": logs,
-                "agent_response": json.dumps({
-                    'pendingSafetyCheck': True,
-                    'messages': ["We've spotted something that might cause the agent to behave unexpectedly! Please acknowledge this to proceed.\n\n > *Type 'ack' to acknowledge and proceed.*"]
-                })
-            }
-        else:
-            return {
-                "logs": logs,
-                "agent_response": agent_response[0]
-            }
+        return {
+            "logs": logs,
+            "agent_response": agent_response
+        }
 
 
     def api_start_container(self):

--- a/spongecake-ui/backend/server.py
+++ b/spongecake-ui/backend/server.py
@@ -148,11 +148,13 @@ class SpongecakeServer:
             logger.error(f"Failed to start noVNC server: {e}")
             raise
     
-    def start_container_if_needed(self, host="", logs: Optional[List[str]] = None) -> Tuple[List[str], int]:
+    def start_container_if_needed(self, host="", logs: Optional[List[str]] = None, isLocal: bool = False) -> Tuple[List[str], int]:
         """Creates a Desktop() object if we don't already have one and starts the container + noVNC server.
         
         Args:
             logs: Optional list to append log messages to
+            isLocal: Whether to start the container in local mode (if you want the agent to run locally on your computer. MacOS only supported right now)
+            host: Optional host to use for the container
             
         Returns:
             Tuple containing logs and the noVNC port
@@ -162,7 +164,7 @@ class SpongecakeServer:
         
         try:
             # 1) Start the Spongecake Desktop container
-            self.desktop = Desktop(name=Config.CONTAINER_NAME, host=host if host != '' else None)
+            self.desktop = Desktop(name=Config.CONTAINER_NAME, host=host if host != '' else None, isLocal = isLocal)
             container = self.desktop.start()
             logs.append(f"🍰 Container started: {container}")
             logger.info(f"🍰 Container started: {container}")
@@ -320,7 +322,8 @@ class SpongecakeServer:
         """
         data = request.get_json()
         host = data.get("host", "")
-        logs, port = self.start_container_if_needed(host)
+        isLocal = data.get("isLocal", False)
+        logs, port = self.start_container_if_needed(host = host, isLocal = isLocal)
         return jsonify({
             "logs": logs,
             "novncPort": port

--- a/spongecake-ui/backend/server.py
+++ b/spongecake-ui/backend/server.py
@@ -15,14 +15,14 @@ try:
     if Version(sc_version) < Version("0.1.15"):
         print("\033[1m\033[38;5;19m" # Bold + dark blue color
             "\n********************************************************************************\n"
-            f"  Spongecake version {sc_version} is too old. Please upgrade to >= 0.1.16.\n"
+            f"  Spongecake version {sc_version} is too old. Please upgrade to >= 0.1.15.\n"
             "  Run ./setup.sh to upgrade."
             "\n********************************************************************************\n\033[0m")
         sys.exit(1)
 except PackageNotFoundError:
     print("\033[1m\033[38;5;52m"  # Bold + dark red color
             "********************************************************************************\n"
-            "Spongecake is not installed. Please install spongecake >= 0.1.16.\n"
+            "Spongecake is not installed. Please install spongecake >= 0.1.15.\n"
             "Run ./setup.sh to install all dependencies.\n"
             "********************************************************************************\n\033[0m")
     sys.exit(1)

--- a/spongecake-ui/backend/server.py
+++ b/spongecake-ui/backend/server.py
@@ -262,7 +262,7 @@ class SpongecakeServer:
         try:
             # Create a wrapper for desktop.action that checks the stop_event
             def run_with_cancellation_check():
-                context = launch_cursor_overlay() if self.desktop.host == 'local' else DockerContext()
+                context = launch_cursor_overlay() if self.desktop.host == 'local' or self.desktop.isLocal and self.desktop.isLocal == True else DockerContext()
                 with context:
                     # Run the agent action
                     if auto_mode:

--- a/spongecake-ui/backend/server.py
+++ b/spongecake-ui/backend/server.py
@@ -1,7 +1,35 @@
+import sys
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    from pkg_resources import get_distribution, DistributionNotFound
+    def version(pkg):
+        return get_distribution(pkg).version
+    PackageNotFoundError = DistributionNotFound
+
+from packaging.version import Version
+
+try:
+    sc_version = version("spongecake")
+    if Version(sc_version) < Version("0.1.15"):
+        print("\033[1m\033[38;5;19m" # Bold + dark blue color
+            "\n********************************************************************************\n"
+            f"  Spongecake version {sc_version} is too old. Please upgrade to >= 0.1.16.\n"
+            "  Run ./setup.sh to upgrade."
+            "\n********************************************************************************\n\033[0m")
+        sys.exit(1)
+except PackageNotFoundError:
+    print("\033[1m\033[38;5;52m"  # Bold + dark red color
+            "********************************************************************************\n"
+            "Spongecake is not installed. Please install spongecake >= 0.1.16.\n"
+            "Run ./setup.sh to install all dependencies.\n"
+            "********************************************************************************\n\033[0m")
+    sys.exit(1)
+
 import logging
 import os
 import subprocess
-import sys
 import threading
 import queue
 import time

--- a/spongecake-ui/frontend/app/page.tsx
+++ b/spongecake-ui/frontend/app/page.tsx
@@ -40,7 +40,7 @@ export default function Home() {
       }
       const resp = await fetch(`${API_BASE_URL}/api/start-container`, {
         method: "POST",
-        body: JSON.stringify({ host: isLocal ? 'local' : '' }),
+        body: JSON.stringify({ isLocal: isLocal }),
         headers: {
           "Content-Type": "application/json",
         },

--- a/spongecake-ui/frontend/app/page.tsx
+++ b/spongecake-ui/frontend/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
   const [logs, setLogs] = useState<string[]>([]);
   const [containerLoading, setContainerLoading] = useState(false);
   const [novncPort, setNovncPort] = useState<number>(6080); // Default port, will be updated
-  const [host, setHost] = useState("");
+  const [isLocal, setIsLocal] = useState(false);
   const [showInstructionsGif, setShowInstructionsGif] = useState(true);
 
 // useEffect to check for local parameter on the URL. Used for when a new window is opened after hitting 'Run locally' 
@@ -25,19 +25,22 @@ export default function Home() {
     const params = new URLSearchParams(window.location.search);
     const isLocal = params.get("isLocal");
     if (isLocal === "true") {
-      setHost("local");
+      setIsLocal(true);
     }
   }, []);
 
 
-  const handleStartContainer = async (host: string = "") => {
+  const handleStartContainer = async ({isLocal = false } : {isLocal?: boolean} = {}) => {
     try {
-      if(host != 'local') {
+      if(isLocal == false) {
         setContainerLoading(true);
+        setIsLocal(false);
+      } else if (isLocal == true) {
+        setIsLocal(true);
       }
       const resp = await fetch(`${API_BASE_URL}/api/start-container`, {
         method: "POST",
-        body: JSON.stringify({ host }),
+        body: JSON.stringify({ host: isLocal ? 'local' : '' }),
         headers: {
           "Content-Type": "application/json",
         },
@@ -51,28 +54,21 @@ export default function Home() {
         setNovncPort(data.novncPort);
       }
 
-      if(host != 'local') {
-        await new Promise(resolve => setTimeout(resolve, 3500));
+      if(isLocal == false) {
+        await new Promise(resolve => setTimeout(resolve, 4000)); // Add delay to give container and VNC server time to start
         setContainerStarted(true);
         setVncShown(true);
-      } else {
+        setLogs(data.logs || []);
+        setContainerLoading(false);
+      } else if (isLocal == true) {
         // Host is local, and we open up a window with the ?isLocal parameter set to true. This will open a chat window and show the local instructions video
         const firstWindow = window.open(
           "http://localhost:3000/?isLocal=true",
           "_blank",
           `width=${Math.floor(window.screen.width * 0.33)},height=${window.screen.height},left=0,top=0,menubar=no,toolbar=no,location=no,resizable=no`
       );
-      if (firstWindow) {
-        firstWindow.focus();
-      } else {
-        console.warn("Window was blocked or failed to open.");
+        if (firstWindow) { firstWindow.focus(); } else { console.warn("Window was blocked or failed to open."); }
       }
-      return
-      }
-      // Wait for 2 seconds before showing the VNC viewer
-      setLogs(data.logs || []);
-      setContainerLoading(false);
-      setHost(host);
     } catch (error) {
         if (error instanceof TypeError && error.message === "Failed to fetch") {
           alert("Failed to fetch. Please make sure the server is running.");
@@ -88,12 +84,12 @@ export default function Home() {
       <MyRuntimeProvider>
         <main className="px-4 py-4 flex-col gap-3 flex items-center">
         <img src={Logo.src} alt="Spongecake Logo" width={300} />
-        {!containerStarted && host == '' && (
+        {!containerStarted && isLocal == false && (
           <div className="flex flex-row gap-2">
           <Button
             disabled={containerLoading}
             className="w-fit font-bold"
-            onClick={() => handleStartContainer('')}
+            onClick={() => handleStartContainer({ isLocal : false })}
           >
             {containerLoading ? <LoaderCircle className="animate-spin" /> : <Play className="" />} Start Docker Agent
           </Button>
@@ -101,7 +97,7 @@ export default function Home() {
             // disabled={desktopLoading}
             className="w-fit font-bold"
             variant={'outline'}
-            onClick={() => handleStartContainer('local')}
+            onClick={() => handleStartContainer({ isLocal: true })}
           >
             <LaptopMinimal />    
             <span className="flex flex-row gap-1 items-center">  
@@ -110,17 +106,7 @@ export default function Home() {
           </Button>
           </div>
         )}
-        {/* View Logs */}
-        {/* {logs.length > 0 && (
-              <div>
-                <h3 className="font-bold">Logs:</h3>
-                <div className="text-sm">
-                  {logs.map((line, idx) => (
-                    <div key={idx}>{line}</div>
-                  ))}
-                </div>
-              </div>
-            )}  */}
+       
         {containerStarted && vncShown && (
 
           <div className="grid grid-cols-3 gap-4 border w-full rounded p-2">
@@ -146,7 +132,7 @@ export default function Home() {
           </div>
         )}
         {/* Local mode - this will just show a chat window which will execute agent on local machine with no container */}
-        {host === 'local' && (
+        {isLocal == true && (
           <div className="flex flex-col gap-3">
             {showInstructionsGif && (
             <div className="flex text-yellow-900 flex-col gap-3 bg-yellow-100 w-fit max-w-[600px] self-center p-3 rounded-lg">

--- a/spongecake-ui/frontend/services/ResponseParser.ts
+++ b/spongecake-ui/frontend/services/ResponseParser.ts
@@ -77,7 +77,7 @@ export class ResponseParser {
     return (
       data.pendingSafetyCheck || 
       (data.agent_response && 
-        (typeof data.agent_response === 'object' && data.agent_response.pendingSafetyCheck) ||
+        (typeof data.agent_response === 'object' && data.agent_response[0].pendingSafetyCheck) ||
         (typeof data.agent_response === 'string' && data.agent_response.includes("pendingSafetyCheck"))
       )
     );
@@ -111,15 +111,15 @@ export class ResponseParser {
       let messages: string[] = [];
       
       // Extract messages from different safety check formats
-      if (data.pendingSafetyCheck && data.agent_response && data.agent_response.messages) {
+      if (data.agent_response && data.agent_response[0].messages && data.agent_response[0].pendingSafetyCheck) {
         // Format 1: Direct object with messages array
-        messages = data.agent_response.messages;
+        messages = ["We've spotted something that might cause the agent to behave unexpectedly! Please acknowledge this to proceed.\n"]; //data.agent_response[0].messages;
       } else if (data.agent_response && typeof data.agent_response === 'string') {
         // Format 2: JSON string that needs parsing
         try {
           const safetyCheckObject = JSON.parse(data.agent_response);
-          if (safetyCheckObject.messages) {
-            messages = safetyCheckObject.messages;
+          if (safetyCheckObject[0].messages) {
+            messages = safetyCheckObject[0].messages;
           }
         } catch (e) {
           console.error("Error parsing safety check JSON:", e);
@@ -164,8 +164,8 @@ export class ResponseParser {
       if (data.agent_response) {
         if (typeof data.agent_response === 'object') {
           // If it's an object, try to stringify it nicely
-          if (data.agent_response.messages && Array.isArray(data.agent_response.messages)) {
-            responseText = data.agent_response.messages.join("\n");
+          if (data.agent_response[0].messages && Array.isArray(data.agent_response[0].messages)) {
+            responseText = data.agent_response[0].messages.join("\n");
           } else {
             responseText = JSON.stringify(data.agent_response, null, 2);
           }


### PR DESCRIPTION
Summary of changes

- add isLocal flag on the front-end rather than using host string 
- add isLocal flag on the SDK and add server piping to pipe the value through appropriately 
- Create a consistent return type for server.py across safety checks, needs input, etc and make sure the front-end handles that appropriately 

Things that could be good to look into for more improvements:
- Does the front-end parsing logic get even more simpler now that agent_response has a consistent structure? 